### PR TITLE
fix: Vercel build — Node.js 18 discontinued, set >=22

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "keywords": [],
     "author": "",
     "license": "ISC",
+    "engines": {
+        "node": ">=22"
+    },
     "devDependencies": {
         "@11ty/eleventy": "^2.0.0",
         "cross-env": "^7.0.3",

--- a/src/site/notes/git/git go back.md
+++ b/src/site/notes/git/git go back.md
@@ -14,8 +14,4 @@ git reset HEAD@{index}
 # magic time machine
 ```
 
-<!-- Test edit 2026-07-30: verifying Vercel publishing pipeline still works. -->
-
-Test edit — Vercel publishing pipeline verified 2026-07-30.
-
 You can use this to get back stuff you accidentally deleted, or just to remove some stuff you tried that broke the repo, or to recover after a bad merge, or just to go back to a time when things actually worked. I use `reflog` A LOT. Mega hat tip to the many many many many many people who suggested adding it!


### PR DESCRIPTION
## Problem

Vercel builds fail with:
```
Found invalid or discontinued Node.js Version: "18.x".
Please set Node.js Version to 24.x in your Project Settings to use Node.js 24.
```

The project has no `engines` field in `package.json`, so Vercel defaults to the old 18.x setting from Jan 2024. Node.js 18 reached end-of-life.

## Fix

Add `"engines": {"node": ">=22"}` to `package.json`. Vercel reads this and uses a supported Node.js version.

Also reverts test edits to `git go back.md` (cleanup from pipeline verification).